### PR TITLE
Annabranch

### DIFF
--- a/src/model/ALU.java
+++ b/src/model/ALU.java
@@ -275,6 +275,13 @@ public class ALU {
 		return toShort(boolArr2);
 	}
 
+	public void compare(Register r, short x2) {
+		resetFlags();
+		short x1 = r.getReg();
+		// by subtracting without returning, comparison is complete
+		subtract(r, x2);
+	}
+
 	public boolean nFlagIsSet() {
 		return nFlag.isSet();
 	}

--- a/src/model/ALU.java
+++ b/src/model/ALU.java
@@ -68,17 +68,6 @@ public class ALU {
 				}
 			}
 		}
-		if (carry) {
-			view.setCbox(true);
-		}
-		short s = toShort(booleanResult);
-		if (s == 0) {
-			zFlag.setFlag(true);
-			view.setZbox(true);
-		} else if (s < 0) {
-			nFlag.setFlag(true);
-			view.setNbox(true);
-		}
 		return s;
 	}
 	

--- a/src/model/ALU.java
+++ b/src/model/ALU.java
@@ -68,7 +68,18 @@ public class ALU {
 				}
 			}
 		}
-		return toShort(booleanResult);
+		if (carry) {
+			view.setCbox(true);
+		}
+		short s = toShort(booleanResult);
+		if (s == 0) {
+			zFlag.setFlag(true);
+			view.setZbox(true);
+		} else if (s < 0) {
+			nFlag.setFlag(true);
+			view.setNbox(true);
+		}
+		return s;
 	}
 	
 	/**

--- a/src/model/ALU.java
+++ b/src/model/ALU.java
@@ -68,7 +68,7 @@ public class ALU {
 				}
 			}
 		}
-		return s;
+		return toShort(booleanResult);
 	}
 	
 	/**

--- a/src/model/ALU.java
+++ b/src/model/ALU.java
@@ -266,7 +266,6 @@ public class ALU {
 
 	public void compare(Register r, short x2) {
 		resetFlags();
-		short x1 = r.getReg();
 		// by subtracting without returning, comparison is complete
 		subtract(r, x2);
 	}

--- a/src/model/ALU.java
+++ b/src/model/ALU.java
@@ -268,6 +268,9 @@ public class ALU {
 		resetFlags();
 		// by subtracting without returning, comparison is complete
 		subtract(r, x2);
+		if (vFlag.isSet()) {
+			nFlag.setFlag(true);
+		}
 	}
 
 	public boolean nFlagIsSet() {

--- a/src/model/CPU.java
+++ b/src/model/CPU.java
@@ -148,6 +148,12 @@ public class CPU {
 			} else if (byte1 == (byte) 0x1A) {
 				//Negate value in accumulator
 				rtnVal = 20;
+			} else if (byte1 == (byte) 0xB0) {
+				//Compare (immediate)
+				rtnVal = 21;
+			} else if (byte1 == (byte) 0xB1) {
+				//Compare (direcT)
+				rtnVal = 22;
 			}
 		}
 		
@@ -332,6 +338,19 @@ public class CPU {
 				} else if (instrType == 20) {
 					//Negate the value stored in the accumulator
 					regA.load(myALU.negate(regA.getReg()));
+				} else if (instrType == 21) {
+					//Compare (immediate)
+					byte operSpec1 = (byte) (((instrReg.getReg() & 0xFF00)) >> 8);
+					byte operSpec2 = (byte) (instrReg.getReg() & 0xFF);
+					progCounter.offset((byte) 2);
+					myALU.compare(regA, fuseBytes(operSpec1, operSpec2));
+				} else if (instrType == 22) {
+					//Compare (direct)
+					byte operSpec1 = (byte) (((instrReg.getReg() & 0xFF00)) >> 8);
+					byte operSpec2 = (byte) (instrReg.getReg() & 0xFF);
+					progCounter.offset((byte) 2);
+					short address = this.calculateDirectAddress(operSpec1, operSpec2);
+					myALU.compare(regA, fuseBytes(m.getDataAt(address), m.getDataAt((short) (address+1))));
 				}
 			} catch (Exception E) {
 				System.out.println("Error in Execution!");


### PR DESCRIPTION
Added compare instruction
Removed increment of PC by 2 when there is no instruction operand (PC should only increment by another 2 after instruction specifier if the instruction has an instruction operand; ASL, ROL, ROR, ASR, and bitwise invert all don't have an instruction operand)